### PR TITLE
Fix small typo in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ cb := circuitbreaker.New(nil)
 data, err := cb.Do(context.Background(), func() (interface{}, error) {
   u, err := fetchUserInfo("john")
   if err == errUserNotFound {
-    return circuitbreaker.Ignore(err) // cb does not treat the err as a failure.
+    return u, circuitbreaker.Ignore(err) // cb does not treat the err as a failure.
   }
   return u, err
 })


### PR DESCRIPTION
First of all thanks for cool library.

I think I've found a little typo in the documentation example. 
