### PR TITLE
Replace archived facebookgo/clock with upstream benbjohnson/clock

### DIFF
--- a/breaker.go
+++ b/breaker.go
@@ -7,8 +7,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/benbjohnson/clock"
 	backoff "github.com/cenkalti/backoff/v3"
-	"github.com/facebookgo/clock"
 )
 
 var (

--- a/breaker_test.go
+++ b/breaker_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/facebookgo/clock"
+	"github.com/benbjohnson/clock"
 	"github.com/mercari/go-circuitbreaker"
 	"github.com/stretchr/testify/assert"
 )

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/mercari/go-circuitbreaker
 go 1.15
 
 require (
+	github.com/benbjohnson/clock v1.3.0
 	github.com/cenkalti/backoff/v3 v3.1.1
-	github.com/facebookgo/clock v0.0.0-20150410010913-600d898af40a
 	github.com/stretchr/testify v1.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,9 @@
+github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
+github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/cenkalti/backoff/v3 v3.1.1 h1:UBHElAnr3ODEbpqPzX8g5sBcASjoLFtt3L/xwJ01L6E=
 github.com/cenkalti/backoff/v3 v3.1.1/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4rc0ij+ULvLYs=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/facebookgo/clock v0.0.0-20150410010913-600d898af40a h1:yDWHCSQ40h88yih2JAcL6Ls/kVkSE8GFACTGVnMPruw=
-github.com/facebookgo/clock v0.0.0-20150410010913-600d898af40a/go.mod h1:7Ga40egUymuWXxAe151lTNnCv97MddSOVsjpPPkityA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/state.go
+++ b/state.go
@@ -1,8 +1,8 @@
 package circuitbreaker
 
 import (
+	"github.com/benbjohnson/clock"
 	"github.com/cenkalti/backoff/v3"
-	"github.com/facebookgo/clock"
 )
 
 // each implementations of state represents State of circuit breaker.

--- a/state_test.go
+++ b/state_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/benbjohnson/clock"
 	"github.com/cenkalti/backoff/v3"
-	"github.com/facebookgo/clock"
 	"github.com/mercari/go-circuitbreaker"
 	"github.com/stretchr/testify/assert"
 )


### PR DESCRIPTION
## Proposed Changes

The facebookgo/clock package was forked from benbjohnson/clock but was
archived at some point. This points to the original package which
appears to still be maintained.

Closes #20

## Checklist

Please read the [CLA (https://www.mercari.com/cla/)](https://www.mercari.com/cla/) carefully before submitting your contribution to Mercari.

- [X] Under any circumstances, by submitting your contribution, you are deemed to accept and agree to be bound by the terms and conditions of the CLA.
