### PR TITLE
Support Go1.15 or higher

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -6,10 +6,9 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - '~1.13'
-          - '~1.14'
           - '~1.15'
           - '~1.16'
+          - '~1.17'
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mercari/go-circuitbreaker
 
-go 1.13
+go 1.15
 
 require (
 	github.com/cenkalti/backoff/v3 v3.1.1


### PR DESCRIPTION
## Proposed Changes

Increase minimal supported version from Go 1.13 to Go 1.15 in order to merge https://github.com/mercari/go-circuitbreaker/pull/21

## Further Comments
https://go.dev/doc/devel/release
`Each major Go release is supported until there are two newer major releases.`
Go itself only supports 2 latest major versions.

## Checklist

Please read the [CLA (https://www.mercari.com/cla/)](https://www.mercari.com/cla/) carefully before submitting your contribution to Mercari.

- [x] Under any circumstances, by submitting your contribution, you are deemed to accept and agree to be bound by the terms and conditions of the CLA.
