### PR TITLE
Support golang 1.18 or higher and type parameters

### DIFF
--- a/v2/breaker.go
+++ b/v2/breaker.go
@@ -1,0 +1,506 @@
+package circuitbreaker
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/benbjohnson/clock"
+	backoff "github.com/cenkalti/backoff/v3"
+)
+
+var (
+	// ErrOpen is an error to signify that the CB is open and executing
+	// operations are not allowed.
+	ErrOpen = errors.New("circuit breaker open")
+
+	// DefaultTripFunc is used when Options.ShouldTrip is nil.
+	DefaultTripFunc = NewTripFuncThreshold(10)
+)
+
+// Default setting parameters.
+const (
+	DefaultInterval             = 1 * time.Second
+	DefaultHalfOpenMaxSuccesses = 4
+)
+
+// State represents the internal state of CB.
+type State[T any] string
+
+// State constants.
+const (
+	StateClosed   State[any] = "closed"
+	StateOpen     State[any] = "open"
+	StateHalfOpen State[any] = "half-open"
+)
+
+// DefaultOpenBackOff returns defaultly used BackOff.
+func DefaultOpenBackOff() backoff.BackOff {
+	_backoff := backoff.NewExponentialBackOff()
+	_backoff.MaxElapsedTime = 0
+	_backoff.Reset()
+	return _backoff
+}
+
+// Counters holds internal counter(s) of CircuitBreaker.
+type Counters struct {
+	Successes            int64
+	Failures             int64
+	ConsecutiveSuccesses int64
+	ConsecutiveFailures  int64
+}
+
+func (c *Counters) reset() { *c = Counters{} }
+
+func (c *Counters) resetSuccesses() {
+	c.Successes = 0
+	c.ConsecutiveSuccesses = 0
+}
+
+func (c *Counters) resetFailures() {
+	c.Failures = 0
+	c.ConsecutiveFailures = 0
+}
+
+func (c *Counters) incrementSuccesses() {
+	c.Successes++
+	c.ConsecutiveSuccesses++
+	c.ConsecutiveFailures = 0
+}
+
+func (c *Counters) incrementFailures() {
+	c.Failures++
+	c.ConsecutiveFailures++
+	c.ConsecutiveSuccesses = 0
+}
+
+// StateChangeHook is a function which will be invoked when the state is changed.
+type StateChangeHook[T any] func(oldState, newState State[T])
+
+// TripFunc is a function to determine if CircuitBreaker should open (trip) or
+// not. TripFunc is called when cb.Fail was called and the state was
+// StateClosed. If TripFunc returns true, the cb's state goes to StateOpen.
+type TripFunc func(*Counters) bool
+
+// NewTripFuncThreshold provides a TripFunc. It returns true if the
+// Failures counter is larger than or equals to threshold.
+func NewTripFuncThreshold(threshold int64) TripFunc {
+	return func(cnt *Counters) bool { return cnt.Failures >= threshold }
+}
+
+// NewTripFuncConsecutiveFailures provides a TripFunc that returns true
+// if the consecutive failures is larger than or equals to threshold.
+func NewTripFuncConsecutiveFailures(threshold int64) TripFunc {
+	return func(cnt *Counters) bool { return cnt.ConsecutiveFailures >= threshold }
+}
+
+// NewTripFuncFailureRate provides a TripFunc that returns true if the failure
+// rate is higher or equals to rate. If the samples are fewer than min, always
+// returns false.
+func NewTripFuncFailureRate(min int64, rate float64) TripFunc {
+	return func(cnt *Counters) bool {
+		if cnt.Successes+cnt.Failures < min {
+			return false
+		}
+		return float64(cnt.Failures)/float64(cnt.Successes+cnt.Failures) >= rate
+	}
+}
+
+// IgnorableError signals that the operation should not be marked as a failure.
+type IgnorableError struct {
+	err error
+}
+
+func (e *IgnorableError) Error() string {
+	return fmt.Sprintf("circuitbreaker does not mark this error as a failure: %s", e.err.Error())
+}
+
+// Unwrap unwraps e.
+func (e *IgnorableError) Unwrap() error { return e.err }
+
+// Ignore wraps the given err in a *IgnorableError.
+func Ignore(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &IgnorableError{err}
+}
+
+// SuccessMarkableError signals that the operation should be mark as success.
+type SuccessMarkableError struct {
+	err error
+}
+
+func (e *SuccessMarkableError) Error() string {
+	return fmt.Sprintf("circuitbreaker mark this error as a success: %s", e.err.Error())
+}
+
+// Unwrap unwraps e.
+func (e *SuccessMarkableError) Unwrap() error { return e.err }
+
+// MarkAsSuccess wraps the given err in a *SuccessMarkableError.
+func MarkAsSuccess(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &SuccessMarkableError{err}
+}
+
+// Options holds CircuitBreaker configuration options.
+type options[T any] struct {
+	// Clock to be used by CircuitBreaker. If nil, real-time clock is
+	// used.
+	clock clock.Clock
+
+	// Interval is the cyclic time period to reset the internal counters
+	// during state is in StateClosed.
+	//
+	// If zero, DefaultInterval is used. If Interval < 0, No interval will
+	// be triggered.
+	interval time.Duration
+
+	// OpenTimeout is the period of StateOpened. After OpenTimeout,
+	// CircuitBreaker's state will be changed to StateHalfOpened. If OpenBackOff
+	// is not nil, OpenTimeout is ignored.
+	openTimeout time.Duration
+
+	// OpenBackOff is a Backoff to determine the period of StateOpened. Every
+	// time the state transitions to StateOpened, OpenBackOff.NextBackOff()
+	// recalculates the period. When the state transitions to StateClosed,
+	// OpenBackOff is reset to the initial state. If both OpenTimeout is zero
+	// value and OpenBackOff is empty, return value of DefaultOpenBackOff() is
+	// used.
+	//
+	// NOTE: Please make sure not to set the ExponentialBackOff.MaxElapsedTime >
+	// 0 for OpenBackOff. If so, your CB don't close after your period of the
+	// StateOpened gets longer than the MaxElapsedTime.
+	openBackOff backoff.BackOff
+
+	// HalfOpenMaxSuccesses is max count of successive successes during the state
+	// is in StateHalfOpened. If the state is StateHalfOpened and the successive
+	// successes reaches this threshold, the state of CircuitBreaker changes
+	// into StateClosed. If zero, DefaultHalfOpenMaxSuccesses is used.
+	halfOpenMaxSuccesses int64
+
+	// ShouldTrips is a function to determine if the CircuitBreaker should
+	// trip. If the state is StateClosed and ShouldTrip returns true,
+	// the state will be changed to StateOpened.
+	// If nil, DefaultTripFunc is used.
+	shouldTrip TripFunc
+
+	// OnStateChange is a function which will be invoked when the state is changed.
+	onStateChange StateChangeHook[T]
+
+	// FailOnContextCancel controls if CircuitBreaker mark an error when the
+	// passed context.Done() is context.Canceled as a fail.
+	failOnContextCancel bool
+
+	// FailOnContextDeadline controls if CircuitBreaker mark an error when the
+	// passed context.Done() is context.DeadlineExceeded as a fail.
+	failOnContextDeadline bool
+}
+
+// CircuitBreaker provides circuit breaker pattern.
+type CircuitBreaker[T any] struct {
+	clock                 clock.Clock
+	interval              time.Duration
+	halfOpenMaxSuccesses  int64
+	openBackOff           backoff.BackOff
+	shouldTrip            TripFunc
+	onStateChange         StateChangeHook[T]
+	failOnContextCancel   bool
+	failOnContextDeadline bool
+
+	mu    sync.RWMutex
+	state state[T]
+	cnt   Counters
+}
+
+type fnApplyOptions[T any] func(*options[T])
+
+// BreakerOption interface for applying configuration in the constructor
+type BreakerOption[T any] interface {
+	apply(*options[T])
+}
+
+func (f fnApplyOptions[T]) apply(options *options[T]) {
+	f(options)
+}
+
+// WithTripFunc Set the function for counter
+func WithTripFunc[T any](tripFunc TripFunc) BreakerOption[T] {
+	return fnApplyOptions[T](func(options *options[T]) {
+		options.shouldTrip = tripFunc
+	})
+}
+
+// WithClock Set the clock
+func WithClock[T any](clock clock.Clock) BreakerOption[T] {
+	return fnApplyOptions[T](func(options *options[T]) {
+		options.clock = clock
+	})
+}
+
+// WithOpenTimeoutBackOff Set the time backoff
+func WithOpenTimeoutBackOff[T any](backoff backoff.BackOff) BreakerOption[T] {
+	return fnApplyOptions[T](func(options *options[T]) {
+		options.openBackOff = backoff
+	})
+}
+
+// WithOpenTimeout Set the timeout of the circuit breaker
+func WithOpenTimeout[T any](timeout time.Duration) BreakerOption[T] {
+	return fnApplyOptions[T](func(options *options[T]) {
+		options.openTimeout = timeout
+	})
+}
+
+// WithHalfOpenMaxSuccesses Set the number of half open successes
+func WithHalfOpenMaxSuccesses[T any](maxSuccesses int64) BreakerOption[T] {
+	return fnApplyOptions[T](func(options *options[T]) {
+		options.halfOpenMaxSuccesses = maxSuccesses
+	})
+}
+
+// WithCounterResetInterval Set the interval of the circuit breaker, which is the cyclic time period to reset the internal counters
+func WithCounterResetInterval[T any](interval time.Duration) BreakerOption[T] {
+	return fnApplyOptions[T](func(options *options[T]) {
+		options.interval = interval
+	})
+}
+
+// WithFailOnContextCancel Set if the context should fail on cancel
+func WithFailOnContextCancel[T any](failOnContextCancel bool) BreakerOption[T] {
+	return fnApplyOptions[T](func(options *options[T]) {
+		options.failOnContextCancel = failOnContextCancel
+	})
+}
+
+// WithFailOnContextDeadline Set if the context should fail on deadline
+func WithFailOnContextDeadline[T any](failOnContextDeadline bool) BreakerOption[T] {
+	return fnApplyOptions[T](func(options *options[T]) {
+		options.failOnContextDeadline = failOnContextDeadline
+	})
+}
+
+// WithOnStateChangeHookFn set a hook function that trigger if the condition of the StateChangeHook is true
+func WithOnStateChangeHookFn[T any](hookFn StateChangeHook[T]) BreakerOption[T] {
+	return fnApplyOptions[T](func(options *options[T]) {
+		options.onStateChange = hookFn
+	})
+}
+
+func defaultOptions[T any]() *options[T] {
+	return &options[T]{
+		shouldTrip:           DefaultTripFunc,
+		clock:                clock.New(),
+		openBackOff:          DefaultOpenBackOff(),
+		openTimeout:          0,
+		halfOpenMaxSuccesses: DefaultHalfOpenMaxSuccesses,
+		interval:             DefaultInterval,
+	}
+}
+
+// New returns a new CircuitBreaker
+// The constructor will be instanced using the functional options pattern. When creating a new circuit breaker
+// we should pass or left it blank if we want to use its default options.
+// An example of the constructor would be like this:
+//
+// cb := circuitbreaker.New(
+//     circuitbreaker.WithClock(clock.New()),
+//     circuitbreaker.WithFailOnContextCancel(true),
+//     circuitbreaker.WithFailOnContextDeadline(true),
+//     circuitbreaker.WithHalfOpenMaxSuccesses(10),
+//     circuitbreaker.WithOpenTimeoutBackOff(backoff.NewExponentialBackOff()),
+//     circuitbreaker.WithOpenTimeout(10*time.Second),
+//     circuitbreaker.WithCounterResetInterval(10*time.Second),
+//     // we also have NewTripFuncThreshold and NewTripFuncConsecutiveFailures
+//     circuitbreaker.WithTripFunc(circuitbreaker.NewTripFuncFailureRate(10, 0.4)),
+//     circuitbreaker.WithOnStateChangeHookFn(func(from, to circuitbreaker.State) {
+//       log.Printf("state changed from %s to %s\n", from, to)
+// 	}),
+// )
+//
+// The default options are described in the defaultOptions function
+func New[T any](opts ...BreakerOption[T]) *CircuitBreaker[T] {
+	cbOptions := defaultOptions[T]()
+
+	for _, opt := range opts {
+		opt.apply(cbOptions)
+	}
+
+	if cbOptions.openTimeout > 0 {
+		cbOptions.openBackOff = backoff.NewConstantBackOff(cbOptions.openTimeout)
+	}
+
+	cb := &CircuitBreaker[T]{
+		shouldTrip:            cbOptions.shouldTrip,
+		onStateChange:         cbOptions.onStateChange,
+		clock:                 cbOptions.clock,
+		interval:              cbOptions.interval,
+		openBackOff:           cbOptions.openBackOff,
+		halfOpenMaxSuccesses:  cbOptions.halfOpenMaxSuccesses,
+		failOnContextCancel:   cbOptions.failOnContextCancel,
+		failOnContextDeadline: cbOptions.failOnContextDeadline,
+	}
+	cb.setState(&stateClosed[T]{})
+	return cb
+}
+
+// An Operation is executed by Do().
+type Operation[T any] func() (T, error)
+
+// Do executes the Operation o and returns the return values if
+// cb.Ready() is true. If not ready, cb doesn't execute f and returns
+// ErrOpen.
+//
+// If o returns a nil-error, cb counts the execution of Operation as a
+// success. Otherwise, cb count it as a failure.
+//
+// If o returns a *IgnorableError, Do() ignores the result of operation and
+// returns the wrapped error.
+//
+// If o returns a *SuccessMarkableError, Do() count it as a success and returns
+// the wrapped error.
+//
+// If given Options' FailOnContextCancel is false (default), cb.Do
+// doesn't mark the Operation's error as a failure if ctx.Err() returns
+// context.Canceled.
+//
+// If given Options' FailOnContextDeadline is false (default), cb.Do
+// doesn't mark the Operation's error as a failure if ctx.Err() returns
+// context.DeadlineExceeded.
+func (cb *CircuitBreaker[T]) Do(ctx context.Context, o Operation[T]) (T, error) {
+	var ret T
+	if !cb.Ready() {
+		return ret, ErrOpen
+	}
+	ret, err := o()
+	return ret, cb.Done(ctx, err)
+}
+
+// Ready reports if cb is ready to execute an operation. Ready does not give
+// any change to cb.
+func (cb *CircuitBreaker[T]) Ready() bool {
+	cb.mu.RLock()
+	defer cb.mu.RUnlock()
+	return cb.state.ready(cb)
+}
+
+// Success signals that an execution of operation has been completed
+// successfully to cb.
+func (cb *CircuitBreaker[T]) Success() {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+	cb.cnt.incrementSuccesses()
+	cb.state.onSuccess(cb)
+}
+
+// Fail signals that an execution of operation has been failed to cb.
+func (cb *CircuitBreaker[T]) Fail() {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+	cb.cnt.incrementFailures()
+	cb.state.onFail(cb)
+}
+
+// FailWithContext calls Fail internally. But if FailOnContextCancel is false
+// and ctx is done with context.Canceled error, no Fail() called. Similarly, if
+// FailOnContextDeadline is false and ctx is done with context.DeadlineExceeded
+// error, no Fail() called.
+func (cb *CircuitBreaker[T]) FailWithContext(ctx context.Context) {
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		if ctxErr == context.Canceled && !cb.failOnContextCancel {
+			return
+		}
+		if ctxErr == context.DeadlineExceeded && !cb.failOnContextDeadline {
+			return
+		}
+	}
+	cb.Fail()
+}
+
+// Done is a helper function to finish the protected operation. If err is nil,
+// Done calls Success and returns nil. If err is a SuccessMarkableError or
+// IgnorableError, Done returns wrapped error. Otherwise, Done calls
+// FailWithContext internally.
+func (cb *CircuitBreaker[T]) Done(ctx context.Context, err error) error {
+	if err == nil {
+		cb.Success()
+		return nil
+	}
+
+	if successMarkableErr, ok := err.(*SuccessMarkableError); ok {
+		cb.Success()
+		return successMarkableErr.Unwrap()
+	}
+
+	if ignorableErr, ok := err.(*IgnorableError); ok {
+		return ignorableErr.Unwrap()
+	}
+
+	cb.FailWithContext(ctx)
+	return err
+}
+
+// State reports the curent State of cb.
+func (cb *CircuitBreaker[T]) State() State[T] {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+	return cb.state.State()
+}
+
+// Counters returns internal counters. If current status is not
+// StateClosed, returns zero value.
+func (cb *CircuitBreaker[T]) Counters() Counters {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+	return cb.cnt
+}
+
+// Reset resets cb's state with StateClosed.
+func (cb *CircuitBreaker[T]) Reset() {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+	cb.cnt.reset()
+	cb.setState(&stateClosed[T]{})
+}
+
+// SetState set state of cb to st.
+func (cb *CircuitBreaker[T]) SetState(st State[T]) {
+	switch st {
+	case State[T](StateClosed):
+		cb.setStateWithLock(&stateClosed[T]{})
+	case State[T](StateOpen):
+		cb.setStateWithLock(&stateOpen[T]{})
+	case State[T](StateHalfOpen):
+		cb.setStateWithLock(&stateHalfOpen[T]{})
+	default:
+		panic("undefined state")
+	}
+}
+
+func (cb *CircuitBreaker[T]) setStateWithLock(s state[T]) {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+	cb.setState(s)
+}
+
+func (cb *CircuitBreaker[T]) setState(s state[T]) {
+	if cb.state != nil {
+		cb.state.onExit(cb)
+	}
+	from := cb.state
+	cb.state = s
+	cb.state.onEntry(cb)
+	cb.handleOnStateChange(from, s)
+}
+
+func (cb *CircuitBreaker[T]) handleOnStateChange(from, to state[T]) {
+	if from == nil || cb.onStateChange == nil {
+		return
+	}
+	cb.onStateChange(from.State(), to.State())
+}

--- a/v2/breaker_test.go
+++ b/v2/breaker_test.go
@@ -1,0 +1,306 @@
+package circuitbreaker_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"testing"
+	"time"
+
+	"github.com/benbjohnson/clock"
+	"github.com/mercari/go-circuitbreaker/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+type user struct {
+	name string
+	age  int
+}
+
+func fetchUserInfo(ctx context.Context, name string) (*user, error) {
+	return &user{name: name, age: 30}, nil
+}
+
+func ExampleCircuitBreaker() {
+	cb := circuitbreaker.New[any](nil)
+	ctx := context.Background()
+
+	data, err := cb.Do(context.Background(), func() (interface{}, error) {
+		user, err := fetchUserInfo(ctx, "太郎")
+		if err != nil && err.Error() == "UserNoFound" {
+			// If you received a application level error, wrap it with Ignore to
+			// avoid false-positive circuit open.
+			return nil, circuitbreaker.Ignore(err)
+		}
+		return user, err
+	})
+
+	if err != nil {
+		log.Fatalf("failed to fetch user:%s\n", err.Error())
+	}
+	log.Printf("fetched user:%+v\n", data.(*user))
+}
+
+func TestDo(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		cb := circuitbreaker.New[string]()
+		got, err := cb.Do(context.Background(), func() (string, error) {
+			return "data", nil
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, "data", got)
+		assert.Equal(t, int64(0), cb.Counters().Failures)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		cb := circuitbreaker.New[string]()
+		wantErr := errors.New("something happens")
+		got, err := cb.Do(context.Background(), func() (string, error) {
+			return "data", wantErr
+		})
+		assert.Equal(t, err, wantErr)
+		assert.Equal(t, "data", got)
+		assert.Equal(t, int64(1), cb.Counters().Failures)
+	})
+
+	t.Run("ignore", func(t *testing.T) {
+		cb := circuitbreaker.New[string]()
+		wantErr := errors.New("something happens")
+		got, err := cb.Do(context.Background(), func() (string, error) { return "data", circuitbreaker.Ignore(wantErr) })
+		assert.Equal(t, err, wantErr)
+		assert.Equal(t, "data", got)
+		assert.Equal(t, int64(0), cb.Counters().Failures)
+	})
+	t.Run("markassuccess", func(t *testing.T) {
+		cb := circuitbreaker.New[string]()
+		wantErr := errors.New("something happens")
+		got, err := cb.Do(context.Background(), func() (string, error) { return "data", circuitbreaker.MarkAsSuccess(wantErr) })
+		assert.Equal(t, err, wantErr)
+		assert.Equal(t, "data", got)
+		assert.Equal(t, int64(0), cb.Counters().Failures)
+	})
+
+	t.Run("context-canceled", func(t *testing.T) {
+		tests := []struct {
+			FailOnContextCancel bool
+			ExpectedFailures    int64
+		}{
+			{FailOnContextCancel: true, ExpectedFailures: 1},
+			{FailOnContextCancel: false, ExpectedFailures: 0},
+		}
+		for _, test := range tests {
+			cancelErr := errors.New("context's Done channel closed.")
+			t.Run(fmt.Sprintf("FailOnContextCanceled=%t", test.FailOnContextCancel), func(t *testing.T) {
+				cb := circuitbreaker.New[string](circuitbreaker.WithFailOnContextCancel[string](test.FailOnContextCancel))
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				got, err := cb.Do(ctx, func() (string, error) {
+					<-ctx.Done()
+					return "", cancelErr
+				})
+				assert.Equal(t, err, cancelErr)
+				assert.Equal(t, "", got)
+				assert.Equal(t, test.ExpectedFailures, cb.Counters().Failures)
+			})
+		}
+	})
+
+	t.Run("context-timeout", func(t *testing.T) {
+		tests := []struct {
+			FailOnContextDeadline bool
+			ExpectedFailures      int64
+		}{
+			{FailOnContextDeadline: true, ExpectedFailures: 1},
+			{FailOnContextDeadline: false, ExpectedFailures: 0},
+		}
+		for _, test := range tests {
+			timeoutErr := errors.New("context's Done channel closed")
+			t.Run(fmt.Sprintf("FailOnContextDeadline=%t", test.FailOnContextDeadline), func(t *testing.T) {
+				cb := circuitbreaker.New[string](circuitbreaker.WithFailOnContextDeadline[string](test.FailOnContextDeadline))
+				ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+				defer cancel()
+				got, err := cb.Do(ctx, func() (string, error) {
+					<-ctx.Done()
+					return "", timeoutErr
+				})
+				assert.Equal(t, err, timeoutErr)
+				assert.Equal(t, "", got)
+				assert.Equal(t, test.ExpectedFailures, cb.Counters().Failures)
+			})
+		}
+	})
+
+	t.Run("cyclic-state-transition", func(t *testing.T) {
+		clkMock := clock.NewMock()
+		cb := circuitbreaker.New[any](circuitbreaker.WithTripFunc[any](circuitbreaker.NewTripFuncThreshold(3)),
+			circuitbreaker.WithClock[any](clkMock),
+			circuitbreaker.WithOpenTimeout[any](1000*time.Millisecond),
+			circuitbreaker.WithHalfOpenMaxSuccesses[any](4))
+
+		wantErr := errors.New("something happens")
+
+		// ( Closed => Open => HalfOpen => Open => HalfOpen => Closed ) x 10 iterations.
+		for i := 0; i < 10; i++ {
+
+			// State: Closed.
+			for i := 0; i < 3; i++ {
+				assert.Equal(t, circuitbreaker.StateClosed, cb.State())
+				got, err := cb.Do(context.Background(), func() (interface{}, error) { return "data", wantErr })
+				assert.Equal(t, err, wantErr)
+				assert.Equal(t, "data", got)
+			}
+
+			// State: Closed => Open. Should return nil and ErrOpen error.
+			assert.Equal(t, circuitbreaker.StateOpen, cb.State())
+			got, err := cb.Do(context.Background(), func() (interface{}, error) { return "data", wantErr })
+			assert.Equal(t, err, circuitbreaker.ErrOpen)
+			assert.Nil(t, got)
+
+			// State: Open => HalfOpen.
+			clkMock.Add(1000 * time.Millisecond)
+			assert.Equal(t, circuitbreaker.StateHalfOpen, cb.State())
+
+			// State: HalfOpen => Open.
+			got, err = cb.Do(context.Background(), func() (interface{}, error) { return "data", wantErr })
+			assert.Equal(t, err, wantErr)
+			assert.Equal(t, "data", got)
+			assert.Equal(t, circuitbreaker.StateOpen, cb.State())
+
+			// State: Open => HalfOpen.
+			clkMock.Add(1000 * time.Millisecond)
+
+			// State: HalfOpen => Close.
+			for i := 0; i < 4; i++ {
+				assert.Equal(t, circuitbreaker.StateHalfOpen, cb.State())
+				got, err = cb.Do(context.Background(), func() (interface{}, error) { return "data", nil })
+				assert.NoError(t, err)
+				assert.Equal(t, "data", got)
+			}
+			assert.Equal(t, circuitbreaker.StateClosed, cb.State())
+		}
+	})
+}
+
+func TestCircuitBreakerTripFuncs(t *testing.T) {
+	t.Run("TripFuncThreshold", func(t *testing.T) {
+		shouldTrip := circuitbreaker.NewTripFuncThreshold(5)
+		assert.False(t, shouldTrip(&circuitbreaker.Counters{Failures: 4}))
+		assert.True(t, shouldTrip(&circuitbreaker.Counters{Failures: 5}))
+		assert.True(t, shouldTrip(&circuitbreaker.Counters{Failures: 6}))
+	})
+	t.Run("TripFuncConsecutiveFailures", func(t *testing.T) {
+		shouldTrip := circuitbreaker.NewTripFuncConsecutiveFailures(5)
+		assert.False(t, shouldTrip(&circuitbreaker.Counters{ConsecutiveFailures: 4}))
+		assert.True(t, shouldTrip(&circuitbreaker.Counters{ConsecutiveFailures: 5}))
+		assert.True(t, shouldTrip(&circuitbreaker.Counters{ConsecutiveFailures: 6}))
+	})
+	t.Run("TripFuncFailureRate", func(t *testing.T) {
+		shouldTrip := circuitbreaker.NewTripFuncFailureRate(10, 0.4)
+		assert.False(t, shouldTrip(&circuitbreaker.Counters{Successes: 1, Failures: 8}))
+		assert.True(t, shouldTrip(&circuitbreaker.Counters{Successes: 1, Failures: 9}))
+		assert.False(t, shouldTrip(&circuitbreaker.Counters{Successes: 60, Failures: 39}))
+		assert.True(t, shouldTrip(&circuitbreaker.Counters{Successes: 60, Failures: 40}))
+		assert.True(t, shouldTrip(&circuitbreaker.Counters{Successes: 60, Failures: 41}))
+	})
+}
+
+func TestIgnore(t *testing.T) {
+	t.Run("nil", func(t *testing.T) {
+		assert.Nil(t, circuitbreaker.Ignore(nil))
+	})
+	t.Run("ignore", func(t *testing.T) {
+		originalErr := errors.New("logic error")
+		if err := circuitbreaker.Ignore(originalErr); err != nil {
+			assert.Equal(t, err.Error(), "circuitbreaker does not mark this error as a failure: logic error")
+			nfe, ok := err.(*circuitbreaker.IgnorableError)
+			assert.True(t, ok)
+			assert.Equal(t, nfe.Unwrap(), originalErr)
+		} else {
+			assert.Fail(t, "there should be an error here")
+		}
+	})
+}
+
+func TestMarkAsSuccess(t *testing.T) {
+	t.Run("nil", func(t *testing.T) {
+		assert.Nil(t, circuitbreaker.MarkAsSuccess(nil))
+	})
+	t.Run("MarkAsSuccess", func(t *testing.T) {
+		originalErr := errors.New("logic error")
+		if err := circuitbreaker.MarkAsSuccess(originalErr); err != nil {
+			assert.Equal(t, err.Error(), "circuitbreaker mark this error as a success: logic error")
+			nfe, ok := err.(*circuitbreaker.SuccessMarkableError)
+			assert.True(t, ok)
+			assert.Equal(t, nfe.Unwrap(), originalErr)
+		} else {
+			assert.Fail(t, "there should be an error here")
+		}
+	})
+}
+
+func TestSuccess(t *testing.T) {
+	cb := circuitbreaker.New[string]()
+	cb.Success()
+	assert.Equal(t, circuitbreaker.Counters{Successes: 1, Failures: 0, ConsecutiveSuccesses: 1, ConsecutiveFailures: 0}, cb.Counters())
+
+	// Test if Success resets ConsecutiveFailures.
+	cb.Fail()
+	cb.Success()
+	assert.Equal(t, circuitbreaker.Counters{Successes: 2, Failures: 1, ConsecutiveSuccesses: 1, ConsecutiveFailures: 0}, cb.Counters())
+
+}
+
+func TestFail(t *testing.T) {
+	cb := circuitbreaker.New[string]()
+	cb.Fail()
+	assert.Equal(t, circuitbreaker.Counters{Successes: 0, Failures: 1, ConsecutiveSuccesses: 0, ConsecutiveFailures: 1}, cb.Counters())
+
+	// Test if Fail resets ConsecutiveSuccesses.
+	cb.Success()
+	cb.Fail()
+	assert.Equal(t, circuitbreaker.Counters{Successes: 1, Failures: 2, ConsecutiveSuccesses: 0, ConsecutiveFailures: 1}, cb.Counters())
+}
+
+// TestReset tests if Reset resets all counters.
+func TestReset(t *testing.T) {
+	cb := circuitbreaker.New[string]()
+	cb.Success()
+	cb.Reset()
+	assert.Equal(t, circuitbreaker.Counters{}, cb.Counters())
+
+	cb.Fail()
+	cb.Reset()
+	assert.Equal(t, circuitbreaker.Counters{}, cb.Counters())
+}
+
+func TestReportFunctions(t *testing.T) {
+	t.Run("Failed if ctx.Err() == nil", func(t *testing.T) {
+		cb := circuitbreaker.New[string]()
+		cb.FailWithContext(context.Background())
+		assert.Equal(t, int64(1), cb.Counters().Failures)
+	})
+	t.Run("ctx.Err() == context.Canceled", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		cb := circuitbreaker.New[string]()
+		cb.FailWithContext(ctx)
+		assert.Equal(t, int64(0), cb.Counters().Failures)
+
+		cb = circuitbreaker.New[string](circuitbreaker.WithFailOnContextCancel[string](true))
+		cb.FailWithContext(ctx)
+		assert.Equal(t, int64(1), cb.Counters().Failures)
+	})
+	t.Run("ctx.Err() == context.DeadlineExceeded", func(t *testing.T) {
+		ctx, cancel := context.WithDeadline(context.Background(), time.Time{})
+		defer cancel()
+		cb := circuitbreaker.New[string]()
+		cb.FailWithContext(ctx)
+		assert.Equal(t, int64(0), cb.Counters().Failures)
+
+		cb = circuitbreaker.New[string](circuitbreaker.WithFailOnContextDeadline[string](true))
+		cb.FailWithContext(ctx)
+		assert.Equal(t, int64(1), cb.Counters().Failures)
+	})
+}

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -1,0 +1,15 @@
+module github.com/mercari/go-circuitbreaker/v2
+
+go 1.18
+
+require (
+	github.com/benbjohnson/clock v1.3.0
+	github.com/cenkalti/backoff/v3 v3.1.1
+	github.com/stretchr/testify v1.4.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v2 v2.2.2 // indirect
+)

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -1,0 +1,15 @@
+github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
+github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
+github.com/cenkalti/backoff/v3 v3.1.1 h1:UBHElAnr3ODEbpqPzX8g5sBcASjoLFtt3L/xwJ01L6E=
+github.com/cenkalti/backoff/v3 v3.1.1/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4rc0ij+ULvLYs=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/v2/state.go
+++ b/v2/state.go
@@ -1,0 +1,127 @@
+package circuitbreaker
+
+import (
+	"github.com/benbjohnson/clock"
+	"github.com/cenkalti/backoff/v3"
+)
+
+// each implementations of state represents State of circuit breaker.
+//
+// ref: https://docs.microsoft.com/en-us/azure/architecture/patterns/circuit-breaker
+type state[T any] interface {
+	State() State[T]
+	onEntry(cb *CircuitBreaker[T])
+	onExit(cb *CircuitBreaker[T])
+	ready(cb *CircuitBreaker[T]) bool
+	onSuccess(cb *CircuitBreaker[T])
+	onFail(cb *CircuitBreaker[T])
+}
+
+// [Closed state]
+//   /onEntry
+//      - Reset counters.
+//      - Start ticker.
+//   /ready
+//      - returns true.
+//   /onFail
+//      - update counters.
+//      - If threshold reached, change state to [Open]
+//   /onTicker
+//      - reset counters.
+//   /onExit
+//      - stop ticker.
+type stateClosed[T any] struct {
+	ticker *clock.Ticker
+	done   chan struct{}
+}
+
+func (st *stateClosed[T]) State() State[T] { return State[T](StateClosed) }
+func (st *stateClosed[T]) onEntry(cb *CircuitBreaker[T]) {
+	cb.cnt.resetFailures()
+	cb.openBackOff.Reset()
+	if cb.interval > 0 {
+		st.ticker = cb.clock.Ticker(cb.interval)
+		st.done = make(chan struct{})
+		go func() {
+			for {
+				select {
+				case <-st.ticker.C:
+					st.onTicker(cb)
+				case <-st.done:
+					st.ticker.Stop()
+					return
+				}
+			}
+		}()
+	}
+}
+
+func (st *stateClosed[T]) onExit(cb *CircuitBreaker[T]) {
+	if st.done != nil {
+		close(st.done)
+	}
+}
+
+func (st *stateClosed[T]) onTicker(cb *CircuitBreaker[T]) {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+	cb.cnt.reset()
+}
+
+func (st *stateClosed[T]) ready(cb *CircuitBreaker[T]) bool { return true }
+func (st *stateClosed[T]) onSuccess(cb *CircuitBreaker[T])  {}
+func (st *stateClosed[T]) onFail(cb *CircuitBreaker[T]) {
+	if cb.shouldTrip(&cb.cnt) {
+		cb.setState(&stateOpen[T]{})
+	}
+}
+
+// [Open state]
+//   /onEntry
+//      - Start timer.
+//   /ready
+//      - Returns false.
+//   /onTimer
+//     - Change state to [HalfOpen].
+//   /onExit
+//     - Stop timer.
+type stateOpen[T any] struct {
+	timer *clock.Timer
+}
+
+func (st *stateOpen[T]) State() State[T] { return State[T](StateOpen) }
+func (st *stateOpen[T]) onEntry(cb *CircuitBreaker[T]) {
+	timeout := cb.openBackOff.NextBackOff()
+	if timeout != backoff.Stop {
+		st.timer = cb.clock.AfterFunc(timeout, func() { st.onTimer(cb) })
+	}
+}
+
+func (st *stateOpen[T]) onTimer(cb *CircuitBreaker[T])    { cb.setStateWithLock(&stateHalfOpen[T]{}) }
+func (st *stateOpen[T]) onExit(cb *CircuitBreaker[T])     { st.timer.Stop() }
+func (st *stateOpen[T]) ready(cb *CircuitBreaker[T]) bool { return false }
+func (st *stateOpen[T]) onSuccess(cb *CircuitBreaker[T])  {}
+func (st *stateOpen[T]) onFail(cb *CircuitBreaker[T])     {}
+
+// [HalfOpen state]
+//   /ready
+//      -> returns true
+//   /onSuccess
+//      -> Increment Success counter.
+//      -> If threshold reached, change state to [Closed].
+//   /onFail
+//      -> change state to [Open].
+type stateHalfOpen[T any] struct{}
+
+func (st *stateHalfOpen[T]) State() State[T]                  { return State[T](StateHalfOpen) }
+func (st *stateHalfOpen[T]) onEntry(cb *CircuitBreaker[T])    { cb.cnt.resetSuccesses() }
+func (st *stateHalfOpen[T]) onExit(cb *CircuitBreaker[T])     {}
+func (st *stateHalfOpen[T]) ready(cb *CircuitBreaker[T]) bool { return true }
+func (st *stateHalfOpen[T]) onSuccess(cb *CircuitBreaker[T]) {
+	if cb.cnt.Successes >= cb.halfOpenMaxSuccesses {
+		cb.setState(&stateClosed[T]{})
+	}
+}
+func (st *stateHalfOpen[T]) onFail(cb *CircuitBreaker[T]) {
+	cb.setState(&stateOpen[T]{})
+}

--- a/v2/state_test.go
+++ b/v2/state_test.go
@@ -1,0 +1,344 @@
+package circuitbreaker_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/benbjohnson/clock"
+	"github.com/cenkalti/backoff/v3"
+	"github.com/mercari/go-circuitbreaker/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCircuitBreakerStateTransitions(t *testing.T) {
+	clk := clock.NewMock()
+	cb := circuitbreaker.New(circuitbreaker.WithTripFunc[any](circuitbreaker.NewTripFuncThreshold(3)),
+		circuitbreaker.WithClock[any](clk),
+		circuitbreaker.WithOpenTimeout[any](1000*time.Millisecond),
+		circuitbreaker.WithHalfOpenMaxSuccesses[any](4))
+
+	for i := 0; i < 10; i++ {
+		// Scenario: 3 Fails. State changes to -> StateOpen.
+		cb.Fail()
+		assert.Equal(t, circuitbreaker.StateClosed, cb.State())
+		cb.Fail()
+		assert.Equal(t, circuitbreaker.StateClosed, cb.State())
+		cb.Fail()
+		assert.Equal(t, circuitbreaker.StateOpen, cb.State())
+
+		// Scenario: After OpenTimeout exceeded. -> StateHalfOpen.
+		assertChangeStateToHalfOpenAfter(t, cb, clk, 1000*time.Millisecond)
+
+		// Scenario: Hit Fail. State back to StateOpen.
+		cb.Fail()
+		assert.Equal(t, circuitbreaker.StateOpen, cb.State())
+
+		// Scenario: After OpenTimeout exceeded. -> StateHalfOpen. (again)
+		assertChangeStateToHalfOpenAfter(t, cb, clk, 1000*time.Millisecond)
+
+		// Scenario: Hit Success. State -> StateClosed.
+		cb.Success()
+		assert.Equal(t, circuitbreaker.StateHalfOpen, cb.State())
+		cb.Success()
+		assert.Equal(t, circuitbreaker.StateHalfOpen, cb.State())
+		cb.Success()
+		assert.Equal(t, circuitbreaker.StateHalfOpen, cb.State())
+		cb.Success()
+		assert.Equal(t, circuitbreaker.StateClosed, cb.State())
+	}
+}
+
+func TestCircuitBreakerOnStateChange(t *testing.T) {
+	type stateChange struct {
+		from circuitbreaker.State[any]
+		to   circuitbreaker.State[any]
+	}
+
+	expectedStateChanges := []stateChange{
+		{
+			from: circuitbreaker.StateClosed,
+			to:   circuitbreaker.StateOpen,
+		},
+		{
+			from: circuitbreaker.StateOpen,
+			to:   circuitbreaker.StateHalfOpen,
+		},
+		{
+			from: circuitbreaker.StateHalfOpen,
+			to:   circuitbreaker.StateOpen,
+		},
+		{
+			from: circuitbreaker.StateOpen,
+			to:   circuitbreaker.StateHalfOpen,
+		},
+		{
+			from: circuitbreaker.StateHalfOpen,
+			to:   circuitbreaker.StateClosed,
+		},
+	}
+	var actualStateChanges []stateChange
+
+	clock := clock.NewMock()
+	cb := circuitbreaker.New[any](
+		circuitbreaker.WithTripFunc[any](circuitbreaker.NewTripFuncThreshold(3)),
+		circuitbreaker.WithClock[any](clock),
+		circuitbreaker.WithOpenTimeout[any](1000*time.Millisecond),
+		circuitbreaker.WithHalfOpenMaxSuccesses[any](4),
+		circuitbreaker.WithOnStateChangeHookFn[any](func(from, to circuitbreaker.State[any]) {
+			actualStateChanges = append(actualStateChanges, stateChange{
+				from: from,
+				to:   to,
+			})
+		}),
+	)
+
+	// Scenario: 3 Fails. State changes to -> StateOpen.
+	cb.Fail()
+	cb.Fail()
+	cb.Fail()
+
+	// Scenario: After OpenTimeout exceeded. -> StateHalfOpen.
+	assertChangeStateToHalfOpenAfter(t, cb, clock, 1000*time.Millisecond)
+
+	// Scenario: Hit Fail. State back to StateOpen.
+	cb.Fail()
+
+	// Scenario: After OpenTimeout exceeded. -> StateHalfOpen. (again)
+	assertChangeStateToHalfOpenAfter(t, cb, clock, 1000*time.Millisecond)
+
+	// Scenario: Hit Success. State -> StateClosed.
+	cb.Success()
+	cb.Success()
+	cb.Success()
+	cb.Success()
+
+	assert.Equal(t, expectedStateChanges, actualStateChanges)
+}
+
+// TestStateClosed tests...
+// - Ready() always returns true.
+// - Change state if Failures threshold reached.
+// - Interval ticker reset the internal counter..
+func TestStateClosed(t *testing.T) {
+	clk := clock.NewMock()
+	cb := circuitbreaker.New[any](circuitbreaker.WithTripFunc[any](circuitbreaker.NewTripFuncThreshold(3)),
+		circuitbreaker.WithClock[any](clk),
+		circuitbreaker.WithCounterResetInterval[any](1000*time.Millisecond))
+
+	t.Run("Ready", func(t *testing.T) {
+		assert.True(t, cb.Ready())
+	})
+
+	t.Run("open-if-shouldtrip-reached", func(t *testing.T) {
+		cb.Reset()
+		cb.Fail()
+		cb.Fail()
+		assert.Equal(t, circuitbreaker.StateClosed, cb.State())
+		cb.Fail()
+		assert.Equal(t, circuitbreaker.StateOpen, cb.State())
+	})
+
+	t.Run("ticker-reset-the-counter", func(t *testing.T) {
+		cb.Reset()
+		cb.Success()
+		cb.Fail()
+		clk.Add(999 * time.Millisecond)
+		assert.Equal(t, circuitbreaker.Counters{Successes: 1, Failures: 1, ConsecutiveFailures: 1}, cb.Counters())
+		clk.Add(1 * time.Millisecond)
+		assert.Equal(t, circuitbreaker.Counters{}, cb.Counters())
+	})
+}
+
+// TestStateOpen tests...
+// - Ready() always returns false.
+// - Change state to StateHalfOpen after timer.
+func TestStateOpen(t *testing.T) {
+	clk := clock.NewMock()
+	cb := circuitbreaker.New[any](circuitbreaker.WithTripFunc[any](circuitbreaker.NewTripFuncThreshold(3)),
+		circuitbreaker.WithClock[any](clk),
+		circuitbreaker.WithOpenTimeout[any](500*time.Millisecond))
+	t.Run("Ready", func(t *testing.T) {
+		cb.SetState(circuitbreaker.StateOpen)
+		assert.False(t, cb.Ready())
+	})
+	t.Run("HalfOpen-when-timer-triggered", func(t *testing.T) {
+		cb.SetState(circuitbreaker.StateOpen)
+		cb.Fail()
+		cb.Success()
+
+		clk.Add(499 * time.Millisecond)
+		assert.Equal(t, circuitbreaker.StateOpen, cb.State())
+
+		clk.Add(1 * time.Millisecond)
+		assert.Equal(t, circuitbreaker.StateHalfOpen, cb.State())
+		assert.Equal(t, circuitbreaker.Counters{Failures: 1}, cb.Counters()) // successes reset.
+	})
+	t.Run("HalfOpen-with-ExponentialOpenBackOff", func(t *testing.T) {
+		clkMock := clock.NewMock()
+		backoffTest := &backoff.ExponentialBackOff{
+			InitialInterval:     1000 * time.Millisecond,
+			RandomizationFactor: 0,
+			Multiplier:          2,
+			MaxInterval:         5 * time.Second,
+			MaxElapsedTime:      0,
+			Clock:               clkMock,
+		}
+		cb := circuitbreaker.New[any](circuitbreaker.WithTripFunc[any](circuitbreaker.NewTripFuncThreshold(1)),
+			circuitbreaker.WithHalfOpenMaxSuccesses[any](1),
+			circuitbreaker.WithClock[any](clkMock),
+			circuitbreaker.WithOpenTimeoutBackOff[any](backoffTest))
+		backoffTest.Reset()
+
+		tests := []struct {
+			f     func()
+			after time.Duration
+		}{
+			{f: cb.Fail, after: 1000 * time.Millisecond},
+			{f: cb.Fail, after: 2000 * time.Millisecond},
+			{f: cb.Fail, after: 4000 * time.Millisecond},
+			{f: cb.Fail, after: 5000 * time.Millisecond},
+			{f: func() { cb.Success(); cb.Fail() }, after: 1000 * time.Millisecond},
+		}
+		for _, test := range tests {
+			test.f()
+			assert.Equal(t, circuitbreaker.StateOpen, cb.State())
+
+			clkMock.Add(test.after - 1)
+			assert.Equal(t, circuitbreaker.StateOpen, cb.State())
+
+			clkMock.Add(1)
+			assert.Equal(t, circuitbreaker.StateHalfOpen, cb.State())
+		}
+	})
+	t.Run("OpenBackOff", func(t *testing.T) {
+		clkMock := clock.NewMock()
+		backoffTest := &backoff.ExponentialBackOff{
+			InitialInterval:     1000 * time.Millisecond,
+			RandomizationFactor: 0,
+			Multiplier:          2,
+			MaxInterval:         5 * time.Second,
+			MaxElapsedTime:      0,
+			Clock:               clkMock,
+		}
+		cb := circuitbreaker.New[any](circuitbreaker.WithTripFunc[any](circuitbreaker.NewTripFuncThreshold(1)),
+			circuitbreaker.WithHalfOpenMaxSuccesses[any](1),
+			circuitbreaker.WithClock[any](clkMock),
+			circuitbreaker.WithOpenTimeoutBackOff[any](backoffTest))
+		backoffTest.Reset()
+
+		tests := []struct {
+			f     func()
+			after time.Duration
+		}{
+			{f: cb.Fail, after: 1000 * time.Millisecond},
+			{f: cb.Fail, after: 2000 * time.Millisecond},
+			{f: cb.Fail, after: 4000 * time.Millisecond},
+			{f: cb.Fail, after: 5000 * time.Millisecond},
+			{f: func() { cb.Success(); cb.Fail() }, after: 1000 * time.Millisecond},
+		}
+		for _, test := range tests {
+			test.f()
+			assertChangeStateToHalfOpenAfter(t, cb, clkMock, test.after)
+		}
+	})
+}
+
+func assertChangeStateToHalfOpenAfter[T any](t *testing.T, cb *circuitbreaker.CircuitBreaker[T], clock *clock.Mock, after time.Duration) {
+	clock.Add(after - 1)
+	assert.Equal(t, circuitbreaker.StateOpen, cb.State())
+
+	clock.Add(1)
+	assert.Equal(t, circuitbreaker.StateHalfOpen, cb.State())
+}
+
+// StateOpen Test
+// - Ready() always returns true.
+// - If get a fail, the state changes to Open.
+// - If get a success, the state changes to Closed.
+func TestHalfOpen(t *testing.T) {
+	clkMock := clock.NewMock()
+	cb := circuitbreaker.New[any](circuitbreaker.WithTripFunc[any](circuitbreaker.NewTripFuncThreshold(3)),
+		circuitbreaker.WithClock[any](clkMock),
+		circuitbreaker.WithHalfOpenMaxSuccesses[any](4))
+	t.Run("Ready", func(t *testing.T) {
+		cb.Reset()
+		cb.SetState(circuitbreaker.StateHalfOpen)
+		assert.True(t, cb.Ready())
+	})
+	t.Run("Open-if-got-a-fail", func(t *testing.T) {
+		cb.Reset()
+		cb.SetState(circuitbreaker.StateHalfOpen)
+
+		cb.Fail()
+		assert.Equal(t, circuitbreaker.StateOpen, cb.State())
+		assert.Equal(t, circuitbreaker.Counters{Failures: 1, ConsecutiveFailures: 1}, cb.Counters()) // no reset
+	})
+	t.Run("Close-if-success-reaches-HalfOpenMaxSuccesses", func(t *testing.T) {
+		cb.Reset()
+		cb.Fail()
+		cb.SetState(circuitbreaker.StateHalfOpen)
+
+		cb.Success()
+		cb.Success()
+		cb.Success()
+		assert.Equal(t, circuitbreaker.StateHalfOpen, cb.State())
+
+		cb.Success()
+		assert.Equal(t, circuitbreaker.StateClosed, cb.State())
+		assert.Equal(t, circuitbreaker.Counters{Successes: 4, Failures: 0, ConsecutiveSuccesses: 4}, cb.Counters()) // Failures reset.
+	})
+}
+
+func run(wg *sync.WaitGroup, f func()) {
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		f()
+	}()
+}
+
+func TestRace(t *testing.T) {
+	clock := clock.NewMock()
+	cb := circuitbreaker.New[any](
+		circuitbreaker.WithTripFunc[any](func(_ *circuitbreaker.Counters) bool { return true }),
+		circuitbreaker.WithClock[any](clock),
+		circuitbreaker.WithCounterResetInterval[any](1000*time.Millisecond),
+	)
+	wg := &sync.WaitGroup{}
+	run(wg, func() {
+		cb.SetState(circuitbreaker.StateClosed)
+	})
+	run(wg, func() {
+		cb.Reset()
+	})
+	run(wg, func() {
+		_ = cb.Done(context.Background(), errors.New(""))
+	})
+	run(wg, func() {
+		_, _ = cb.Do(context.Background(), func() (interface{}, error) {
+			return nil, nil
+		})
+	})
+	run(wg, func() {
+		cb.State()
+	})
+	run(wg, func() {
+		cb.Fail()
+	})
+	run(wg, func() {
+		cb.Counters()
+	})
+	run(wg, func() {
+		cb.Ready()
+	})
+	run(wg, func() {
+		cb.Success()
+	})
+	run(wg, func() {
+		cb.FailWithContext(context.Background())
+	})
+	wg.Wait()
+}


### PR DESCRIPTION
## Proposed Changes
* Increase minimal supported version from Go 1.15 to Go 1.18
* Bump up to v2
* Support type parameters

## Further Comments
Support Go 1.18 Type parameters.

## Checklist

Please read the [CLA (https://www.mercari.com/cla/)](https://www.mercari.com/cla/) carefully before submitting your contribution to Mercari.

- [x] Under any circumstances, by submitting your contribution, you are deemed to accept and agree to be bound by the terms and conditions of the CLA.
