### PR TITLE
chore: modernize Go module, dependencies, and CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,8 +5,8 @@ jobs:
     name: lint library
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@5c56cd6c9dc07901af25baab6f2b0d9f3b7c3018 # v2.5.2
         with:
-          version: v1.29
+          version: v1.29.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,7 +6,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@5c56cd6c9dc07901af25baab6f2b0d9f3b7c3018 # v2.5.2
+      - uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa # v7.0.1
         with:
-          version: v1.29.0
+          version: v2.11.4

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -6,12 +6,11 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - '~1.15'
-          - '~1.16'
-          - '~1.17'
+          - '~1.25'
+          - '~1.26'
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: ${{ matrix.go-version }}
       - run: go test -race -v ./...

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ var cb = circuitbreaker.New()
 
 func getUserInfo(ctx context.Context, name string) (_ *User,err error) {
   if !cb.Ready() {
-    return nil, circuitbreaker.ErrOpened
+    return nil, circuitbreaker.ErrOpen
   }
   defer func() { err = cb.Done(ctx, err) }
 
@@ -81,7 +81,7 @@ The same for timeouts configuration. Especially on gRPC, clients are able to set
 Sometimes, we would like to receive an error from a protected operation but don't want to mark the request as a failure. For example, a case that protected HTTP request responded 404 NotFound. This application-level error is obviously not caused by a failure, so that we'd like to return nil error, but want to receive non-nil error. Because `go-circuitbreaker` is able to receive errors from protected operations without making them as failures, you don't need to write complicated error handlings in order to achieve your goal.
 
 ```go
-cb := circuitbreaker.New(nil)
+cb := circuitbreaker.New()
 
 data, err := cb.Do(context.Background(), func() (interface{}, error) {
   u, err := fetchUserInfo("john")

--- a/breaker.go
+++ b/breaker.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/benbjohnson/clock"
-	backoff "github.com/cenkalti/backoff/v3"
+	backoff "github.com/cenkalti/backoff/v5"
 )
 
 var (
@@ -39,7 +39,6 @@ const (
 // DefaultOpenBackOff returns defaultly used BackOff.
 func DefaultOpenBackOff() backoff.BackOff {
 	_backoff := backoff.NewExponentialBackOff()
-	_backoff.MaxElapsedTime = 0
 	_backoff.Reset()
 	return _backoff
 }
@@ -309,18 +308,20 @@ func defaultOptions() *options {
 // An example of the constructor would be like this:
 //
 // cb := circuitbreaker.New(
-//     circuitbreaker.WithClock(clock.New()),
-//     circuitbreaker.WithFailOnContextCancel(true),
-//     circuitbreaker.WithFailOnContextDeadline(true),
-//     circuitbreaker.WithHalfOpenMaxSuccesses(10),
-//     circuitbreaker.WithOpenTimeoutBackOff(backoff.NewExponentialBackOff()),
-//     circuitbreaker.WithOpenTimeout(10*time.Second),
-//     circuitbreaker.WithCounterResetInterval(10*time.Second),
-//     // we also have NewTripFuncThreshold and NewTripFuncConsecutiveFailures
-//     circuitbreaker.WithTripFunc(circuitbreaker.NewTripFuncFailureRate(10, 0.4)),
-//     circuitbreaker.WithOnStateChangeHookFn(func(from, to circuitbreaker.State) {
-//       log.Printf("state changed from %s to %s\n", from, to)
-// 	}),
+//
+//	    circuitbreaker.WithClock(clock.New()),
+//	    circuitbreaker.WithFailOnContextCancel(true),
+//	    circuitbreaker.WithFailOnContextDeadline(true),
+//	    circuitbreaker.WithHalfOpenMaxSuccesses(10),
+//	    circuitbreaker.WithOpenTimeoutBackOff(backoff.NewExponentialBackOff()),
+//	    circuitbreaker.WithOpenTimeout(10*time.Second),
+//	    circuitbreaker.WithCounterResetInterval(10*time.Second),
+//	    // we also have NewTripFuncThreshold and NewTripFuncConsecutiveFailures
+//	    circuitbreaker.WithTripFunc(circuitbreaker.NewTripFuncFailureRate(10, 0.4)),
+//	    circuitbreaker.WithOnStateChangeHookFn(func(from, to circuitbreaker.State) {
+//	      log.Printf("state changed from %s to %s\n", from, to)
+//		}),
+//
 // )
 //
 // The default options are described in the defaultOptions function

--- a/breaker.go
+++ b/breaker.go
@@ -350,32 +350,40 @@ func New(opts ...BreakerOption) *CircuitBreaker {
 	return cb
 }
 
-// An Operation is executed by Do().
-type Operation func() (interface{}, error)
+// An Operation is executed by Do method.
+//
+// Deprecated: Use the package-level generic function Do instead.
+type Operation func() (any, error)
 
 // Do executes the Operation o and returns the return values if
 // cb.Ready() is true. If not ready, cb doesn't execute f and returns
 // ErrOpen.
 //
-// If o returns a nil-error, cb counts the execution of Operation as a
-// success. Otherwise, cb count it as a failure.
-//
-// If o returns a *IgnorableError, Do() ignores the result of operation and
-// returns the wrapped error.
-//
-// If o returns a *SuccessMarkableError, Do() count it as a success and returns
-// the wrapped error.
-//
-// If given Options' FailOnContextCancel is false (default), cb.Do
-// doesn't mark the Operation's error as a failure if ctx.Err() returns
-// context.Canceled.
-//
-// If given Options' FailOnContextDeadline is false (default), cb.Do
-// doesn't mark the Operation's error as a failure if ctx.Err() returns
-// context.DeadlineExceeded.
-func (cb *CircuitBreaker) Do(ctx context.Context, o Operation) (interface{}, error) {
+// Deprecated: Use the package-level generic function Do instead for type safety.
+func (cb *CircuitBreaker) Do(ctx context.Context, o Operation) (any, error) {
 	if !cb.Ready() {
 		return nil, ErrOpen
+	}
+	result, err := o()
+	return result, cb.Done(ctx, err)
+}
+
+// Do executes the operation o with type safety using generics.
+// If cb.Ready() is true, it executes o and returns the result.
+// If not ready, it returns the zero value of T and ErrOpen.
+//
+// If o returns a nil-error, cb counts the execution as a success.
+// Otherwise, cb counts it as a failure.
+//
+// If o returns a *IgnorableError, Do ignores the result of operation and
+// returns the wrapped error.
+//
+// If o returns a *SuccessMarkableError, Do counts it as a success and returns
+// the wrapped error.
+func Do[T any](cb *CircuitBreaker, ctx context.Context, o func() (T, error)) (T, error) {
+	if !cb.Ready() {
+		var zero T
+		return zero, ErrOpen
 	}
 	result, err := o()
 	return result, cb.Done(ctx, err)

--- a/breaker.go
+++ b/breaker.go
@@ -350,7 +350,7 @@ func New(opts ...BreakerOption) *CircuitBreaker {
 	return cb
 }
 
-// An Operation is executed by Do method.
+// An Operation is executed by Do().
 //
 // Deprecated: Use the package-level generic function Do instead.
 type Operation func() (any, error)
@@ -359,7 +359,24 @@ type Operation func() (any, error)
 // cb.Ready() is true. If not ready, cb doesn't execute f and returns
 // ErrOpen.
 //
-// Deprecated: Use the package-level generic function Do instead for type safety.
+// If o returns a nil-error, cb counts the execution of Operation as a
+// success. Otherwise, cb count it as a failure.
+//
+// If o returns a *IgnorableError, Do() ignores the result of operation and
+// returns the wrapped error.
+//
+// If o returns a *SuccessMarkableError, Do() count it as a success and returns
+// the wrapped error.
+//
+// If given Options' FailOnContextCancel is false (default), cb.Do
+// doesn't mark the Operation's error as a failure if ctx.Err() returns
+// context.Canceled.
+//
+// If given Options' FailOnContextDeadline is false (default), cb.Do
+// doesn't mark the Operation's error as a failure if ctx.Err() returns
+// context.DeadlineExceeded.
+//
+// Deprecated: Use the package-level generic function Do instead.
 func (cb *CircuitBreaker) Do(ctx context.Context, o Operation) (any, error) {
 	if !cb.Ready() {
 		return nil, ErrOpen
@@ -368,18 +385,26 @@ func (cb *CircuitBreaker) Do(ctx context.Context, o Operation) (any, error) {
 	return result, cb.Done(ctx, err)
 }
 
-// Do executes the operation o with type safety using generics.
-// If cb.Ready() is true, it executes o and returns the result.
-// If not ready, it returns the zero value of T and ErrOpen.
+// Do executes the operation o and returns the return values if
+// cb.Ready() is true. If not ready, it returns the zero value of T and
+// ErrOpen.
 //
-// If o returns a nil-error, cb counts the execution as a success.
-// Otherwise, cb counts it as a failure.
+// If o returns a nil-error, cb counts the execution of Operation as a
+// success. Otherwise, cb count it as a failure.
 //
-// If o returns a *IgnorableError, Do ignores the result of operation and
+// If o returns a *IgnorableError, Do() ignores the result of operation and
 // returns the wrapped error.
 //
-// If o returns a *SuccessMarkableError, Do counts it as a success and returns
+// If o returns a *SuccessMarkableError, Do() count it as a success and returns
 // the wrapped error.
+//
+// If given Options' FailOnContextCancel is false (default), Do
+// doesn't mark the Operation's error as a failure if ctx.Err() returns
+// context.Canceled.
+//
+// If given Options' FailOnContextDeadline is false (default), Do
+// doesn't mark the Operation's error as a failure if ctx.Err() returns
+// context.DeadlineExceeded.
 func Do[T any](cb *CircuitBreaker, ctx context.Context, o func() (T, error)) (T, error) {
 	if !cb.Ready() {
 		var zero T

--- a/breaker.go
+++ b/breaker.go
@@ -412,10 +412,10 @@ func (cb *CircuitBreaker) Fail() {
 // error, no Fail() called.
 func (cb *CircuitBreaker) FailWithContext(ctx context.Context) {
 	if ctxErr := ctx.Err(); ctxErr != nil {
-		if ctxErr == context.Canceled && !cb.failOnContextCancel {
+		if errors.Is(ctxErr, context.Canceled) && !cb.failOnContextCancel {
 			return
 		}
-		if ctxErr == context.DeadlineExceeded && !cb.failOnContextDeadline {
+		if errors.Is(ctxErr, context.DeadlineExceeded) && !cb.failOnContextDeadline {
 			return
 		}
 	}
@@ -432,12 +432,14 @@ func (cb *CircuitBreaker) Done(ctx context.Context, err error) error {
 		return nil
 	}
 
-	if successMarkableErr, ok := err.(*SuccessMarkableError); ok {
+	var successMarkableErr *SuccessMarkableError
+	if errors.As(err, &successMarkableErr) {
 		cb.Success()
 		return successMarkableErr.Unwrap()
 	}
 
-	if ignorableErr, ok := err.(*IgnorableError); ok {
+	var ignorableErr *IgnorableError
+	if errors.As(err, &ignorableErr) {
 		return ignorableErr.Unwrap()
 	}
 

--- a/breaker_test.go
+++ b/breaker_test.go
@@ -23,7 +23,7 @@ func fetchUserInfo(ctx context.Context, name string) (*user, error) {
 }
 
 func ExampleCircuitBreaker() {
-	cb := circuitbreaker.New(nil)
+	cb := circuitbreaker.New()
 	ctx := context.Background()
 
 	data, err := cb.Do(context.Background(), func() (interface{}, error) {

--- a/breaker_test.go
+++ b/breaker_test.go
@@ -35,7 +35,6 @@ func ExampleCircuitBreaker() {
 		}
 		return user, err
 	})
-
 	if err != nil {
 		log.Fatalf("failed to fetch user:%s\n", err.Error())
 	}
@@ -182,6 +181,170 @@ func TestDo(t *testing.T) {
 	})
 }
 
+func TestDoGeneric(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		cb := circuitbreaker.New()
+		got, err := circuitbreaker.Do[string](cb, context.Background(), func() (string, error) {
+			return "data", nil
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, "data", got)
+		assert.Equal(t, int64(0), cb.Counters().Failures)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		cb := circuitbreaker.New()
+		wantErr := errors.New("something happens")
+		got, err := circuitbreaker.Do[string](cb, context.Background(), func() (string, error) {
+			return "data", wantErr
+		})
+		assert.Equal(t, wantErr, err)
+		assert.Equal(t, "data", got)
+		assert.Equal(t, int64(1), cb.Counters().Failures)
+	})
+
+	t.Run("open", func(t *testing.T) {
+		cb := circuitbreaker.New(circuitbreaker.WithTripFunc(circuitbreaker.NewTripFuncThreshold(1)))
+		cb.Fail()
+		got, err := circuitbreaker.Do[string](cb, context.Background(), func() (string, error) {
+			return "data", nil
+		})
+		assert.Equal(t, circuitbreaker.ErrOpen, err)
+		assert.Equal(t, "", got)
+	})
+
+	t.Run("ignore", func(t *testing.T) {
+		cb := circuitbreaker.New()
+		wantErr := errors.New("something happens")
+		got, err := circuitbreaker.Do[string](cb, context.Background(), func() (string, error) {
+			return "data", circuitbreaker.Ignore(wantErr)
+		})
+		assert.Equal(t, wantErr, err)
+		assert.Equal(t, "data", got)
+		assert.Equal(t, int64(0), cb.Counters().Failures)
+	})
+
+	t.Run("markassuccess", func(t *testing.T) {
+		cb := circuitbreaker.New()
+		wantErr := errors.New("something happens")
+		got, err := circuitbreaker.Do[string](cb, context.Background(), func() (string, error) {
+			return "data", circuitbreaker.MarkAsSuccess(wantErr)
+		})
+		assert.Equal(t, wantErr, err)
+		assert.Equal(t, "data", got)
+		assert.Equal(t, int64(0), cb.Counters().Failures)
+	})
+
+	t.Run("context-canceled", func(t *testing.T) {
+		tests := []struct {
+			FailOnContextCancel bool
+			ExpectedFailures    int64
+		}{
+			{FailOnContextCancel: true, ExpectedFailures: 1},
+			{FailOnContextCancel: false, ExpectedFailures: 0},
+		}
+		for _, test := range tests {
+			cancelErr := errors.New("context's Done channel closed.")
+			t.Run(fmt.Sprintf("FailOnContextCanceled=%t", test.FailOnContextCancel), func(t *testing.T) {
+				cb := circuitbreaker.New(circuitbreaker.WithFailOnContextCancel(test.FailOnContextCancel))
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				got, err := circuitbreaker.Do[string](cb, ctx, func() (string, error) {
+					<-ctx.Done()
+					return "", cancelErr
+				})
+				assert.Equal(t, cancelErr, err)
+				assert.Equal(t, "", got)
+				assert.Equal(t, test.ExpectedFailures, cb.Counters().Failures)
+			})
+		}
+	})
+
+	t.Run("context-timeout", func(t *testing.T) {
+		tests := []struct {
+			FailOnContextDeadline bool
+			ExpectedFailures      int64
+		}{
+			{FailOnContextDeadline: true, ExpectedFailures: 1},
+			{FailOnContextDeadline: false, ExpectedFailures: 0},
+		}
+		for _, test := range tests {
+			timeoutErr := errors.New("context's Done channel closed")
+			t.Run(fmt.Sprintf("FailOnContextDeadline=%t", test.FailOnContextDeadline), func(t *testing.T) {
+				cb := circuitbreaker.New(circuitbreaker.WithFailOnContextDeadline(test.FailOnContextDeadline))
+				ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+				defer cancel()
+				got, err := circuitbreaker.Do[string](cb, ctx, func() (string, error) {
+					<-ctx.Done()
+					return "", timeoutErr
+				})
+				assert.Equal(t, timeoutErr, err)
+				assert.Equal(t, "", got)
+				assert.Equal(t, test.ExpectedFailures, cb.Counters().Failures)
+			})
+		}
+	})
+
+	t.Run("struct-type", func(t *testing.T) {
+		cb := circuitbreaker.New()
+		got, err := circuitbreaker.Do[*user](cb, context.Background(), func() (*user, error) {
+			return &user{name: "太郎", age: 30}, nil
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, &user{name: "太郎", age: 30}, got)
+	})
+
+	t.Run("cyclic-state-transition", func(t *testing.T) {
+		clkMock := clock.NewMock()
+		cb := circuitbreaker.New(circuitbreaker.WithTripFunc(circuitbreaker.NewTripFuncThreshold(3)),
+			circuitbreaker.WithClock(clkMock),
+			circuitbreaker.WithOpenTimeout(1000*time.Millisecond),
+			circuitbreaker.WithHalfOpenMaxSuccesses(4))
+
+		wantErr := errors.New("something happens")
+
+		// ( Closed => Open => HalfOpen => Open => HalfOpen => Closed ) x 10 iterations.
+		for i := 0; i < 10; i++ {
+
+			// State: Closed.
+			for i := 0; i < 3; i++ {
+				assert.Equal(t, circuitbreaker.StateClosed, cb.State())
+				got, err := circuitbreaker.Do[string](cb, context.Background(), func() (string, error) { return "data", wantErr })
+				assert.Equal(t, wantErr, err)
+				assert.Equal(t, "data", got)
+			}
+
+			// State: Closed => Open. Should return zero value and ErrOpen error.
+			assert.Equal(t, circuitbreaker.StateOpen, cb.State())
+			got, err := circuitbreaker.Do[string](cb, context.Background(), func() (string, error) { return "data", wantErr })
+			assert.Equal(t, circuitbreaker.ErrOpen, err)
+			assert.Equal(t, "", got)
+
+			// State: Open => HalfOpen.
+			clkMock.Add(1000 * time.Millisecond)
+			assert.Equal(t, circuitbreaker.StateHalfOpen, cb.State())
+
+			// State: HalfOpen => Open.
+			got, err = circuitbreaker.Do[string](cb, context.Background(), func() (string, error) { return "data", wantErr })
+			assert.Equal(t, wantErr, err)
+			assert.Equal(t, "data", got)
+			assert.Equal(t, circuitbreaker.StateOpen, cb.State())
+
+			// State: Open => HalfOpen.
+			clkMock.Add(1000 * time.Millisecond)
+
+			// State: HalfOpen => Close.
+			for i := 0; i < 4; i++ {
+				assert.Equal(t, circuitbreaker.StateHalfOpen, cb.State())
+				got, err = circuitbreaker.Do[string](cb, context.Background(), func() (string, error) { return "data", nil })
+				assert.NoError(t, err)
+				assert.Equal(t, "data", got)
+			}
+			assert.Equal(t, circuitbreaker.StateClosed, cb.State())
+		}
+	})
+}
+
 func TestCircuitBreakerTripFuncs(t *testing.T) {
 	t.Run("TripFuncThreshold", func(t *testing.T) {
 		shouldTrip := circuitbreaker.NewTripFuncThreshold(5)
@@ -248,7 +411,6 @@ func TestSuccess(t *testing.T) {
 	cb.Fail()
 	cb.Success()
 	assert.Equal(t, circuitbreaker.Counters{Successes: 2, Failures: 1, ConsecutiveSuccesses: 1, ConsecutiveFailures: 0}, cb.Counters())
-
 }
 
 func TestFail(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.2
 
 require (
 	github.com/benbjohnson/clock v1.3.0
-	github.com/cenkalti/backoff/v3 v3.1.1
+	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/stretchr/testify v1.4.0
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,15 @@
 module github.com/mercari/go-circuitbreaker
 
-go 1.15
+go 1.26.2
 
 require (
 	github.com/benbjohnson/clock v1.3.0
 	github.com/cenkalti/backoff/v3 v3.1.1
 	github.com/stretchr/testify v1.4.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v2 v2.2.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
-github.com/cenkalti/backoff/v3 v3.1.1 h1:UBHElAnr3ODEbpqPzX8g5sBcASjoLFtt3L/xwJ01L6E=
-github.com/cenkalti/backoff/v3 v3.1.1/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4rc0ij+ULvLYs=
+github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
+github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/state.go
+++ b/state.go
@@ -2,7 +2,7 @@ package circuitbreaker
 
 import (
 	"github.com/benbjohnson/clock"
-	"github.com/cenkalti/backoff/v3"
+	"github.com/cenkalti/backoff/v5"
 )
 
 // each implementations of state represents State of circuit breaker.
@@ -18,18 +18,19 @@ type state interface {
 }
 
 // [Closed state]
-//   /onEntry
-//      - Reset counters.
-//      - Start ticker.
-//   /ready
-//      - returns true.
-//   /onFail
-//      - update counters.
-//      - If threshold reached, change state to [Open]
-//   /onTicker
-//      - reset counters.
-//   /onExit
-//      - stop ticker.
+//
+//	/onEntry
+//	   - Reset counters.
+//	   - Start ticker.
+//	/ready
+//	   - returns true.
+//	/onFail
+//	   - update counters.
+//	   - If threshold reached, change state to [Open]
+//	/onTicker
+//	   - reset counters.
+//	/onExit
+//	   - stop ticker.
 type stateClosed struct {
 	ticker *clock.Ticker
 	done   chan struct{}
@@ -77,14 +78,15 @@ func (st *stateClosed) onFail(cb *CircuitBreaker) {
 }
 
 // [Open state]
-//   /onEntry
-//      - Start timer.
-//   /ready
-//      - Returns false.
-//   /onTimer
-//     - Change state to [HalfOpen].
-//   /onExit
-//     - Stop timer.
+//
+//	/onEntry
+//	   - Start timer.
+//	/ready
+//	   - Returns false.
+//	/onTimer
+//	  - Change state to [HalfOpen].
+//	/onExit
+//	  - Stop timer.
 type stateOpen struct {
 	timer *clock.Timer
 }
@@ -104,13 +106,14 @@ func (st *stateOpen) onSuccess(cb *CircuitBreaker)  {}
 func (st *stateOpen) onFail(cb *CircuitBreaker)     {}
 
 // [HalfOpen state]
-//   /ready
-//      -> returns true
-//   /onSuccess
-//      -> Increment Success counter.
-//      -> If threshold reached, change state to [Closed].
-//   /onFail
-//      -> change state to [Open].
+//
+//	/ready
+//	   -> returns true
+//	/onSuccess
+//	   -> Increment Success counter.
+//	   -> If threshold reached, change state to [Closed].
+//	/onFail
+//	   -> change state to [Open].
 type stateHalfOpen struct{}
 
 func (st *stateHalfOpen) State() State                  { return StateHalfOpen }
@@ -122,6 +125,7 @@ func (st *stateHalfOpen) onSuccess(cb *CircuitBreaker) {
 		cb.setState(&stateClosed{})
 	}
 }
+
 func (st *stateHalfOpen) onFail(cb *CircuitBreaker) {
 	cb.setState(&stateOpen{})
 }

--- a/state_test.go
+++ b/state_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/benbjohnson/clock"
-	"github.com/cenkalti/backoff/v3"
+	"github.com/cenkalti/backoff/v5"
 	"github.com/mercari/go-circuitbreaker"
 	"github.com/stretchr/testify/assert"
 )
@@ -183,8 +183,6 @@ func TestStateOpen(t *testing.T) {
 			RandomizationFactor: 0,
 			Multiplier:          2,
 			MaxInterval:         5 * time.Second,
-			MaxElapsedTime:      0,
-			Clock:               clkMock,
 		}
 		cb := circuitbreaker.New(circuitbreaker.WithTripFunc(circuitbreaker.NewTripFuncThreshold(1)),
 			circuitbreaker.WithHalfOpenMaxSuccesses(1),
@@ -220,8 +218,6 @@ func TestStateOpen(t *testing.T) {
 			RandomizationFactor: 0,
 			Multiplier:          2,
 			MaxInterval:         5 * time.Second,
-			MaxElapsedTime:      0,
-			Clock:               clkMock,
 		}
 		cb := circuitbreaker.New(circuitbreaker.WithTripFunc(circuitbreaker.NewTripFuncThreshold(1)),
 			circuitbreaker.WithHalfOpenMaxSuccesses(1),


### PR DESCRIPTION
## Proposed Changes

Modernize the project to align with current Go ecosystem standards:

- Bump Go version from 1.15 to 1.26.2
- Upgrade `cenkalti/backoff` from v3 to v5
- Use `errors.Is` and `errors.As` for proper error unwrapping
- Add generic `Do[T]` function for type-safe operation execution
- Pin GitHub Actions to SHA and update Go test matrix (1.25, 1.26)
- Upgrade golangci-lint to v2.11.4 with action v7
- Fix typos in README (`ErrOpened` → `ErrOpen`, `New(nil)` → `New()`)

## Further Comments

- The existing `Operation` type and `cb.Do()` method are preserved for backward compatibility and marked as `Deprecated`.
- The new `Do[T]` package-level function provides type-safe operation execution without requiring type assertions.
- `cenkalti/backoff` v5 removed `MaxElapsedTime` and `Clock` from `ExponentialBackOff`. These were already unused or set to zero-value defaults, so no behavioral change.

## Checklist

- [x] Under any circumstances, by submitting your contribution, you are deemed to accept and agree to be bound by the terms and conditions of the CLA.